### PR TITLE
fix: remove delay hack when positioning the caret after applying formatting

### DIFF
--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -144,7 +144,7 @@
 
 		// HACK:
 		// Delay setting the new caret position until the input has been formatted.
-		// If this is ever fixed consider removing `{ delay: DELAY_FOR_DECIMAL_VALUES_IN_MS }` in the tests.
+		// If this is ever fixed consider removing `{ delay: DELAY_FOR_FORMATTED_VALUE_IN_MS }` in the tests.
 		setTimeout(() => {
 			inputTarget?.setSelectionRange(endCaretPosition, endCaretPosition);
 		}, DELAY_FOR_CARET_UPDATE_IN_MS);

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -136,19 +136,14 @@
 		// Update `value` after formatting
 		setUnformattedValue();
 
-		// New caret position
-		const endCaretPosition =
-			startCaretPosition + formattedValue.length - previousFormattedValueLength;
+		let retries = 0;
+		while (previousFormattedValueLength === formattedValue.length && retries < 10) retries++;
 
-		let tries = 0;
-    while (previousFormattedValueLength === formattedValue.length && tries < 10) {
-			tries++;
-    }
-
-    if (previousFormattedValueLength !== formattedValue.length) {
-			const endCaretPosition = startCaretPosition + formattedValue.length - previousFormattedValueLength;
+		if (previousFormattedValueLength !== formattedValue.length) {
+			const endCaretPosition =
+				startCaretPosition + formattedValue.length - previousFormattedValueLength;
 			inputTarget?.setSelectionRange(endCaretPosition, endCaretPosition);
-    }
+		}
 
 		// Run callback function when `value` changes
 		onValueChange(value);

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -142,12 +142,15 @@
 		const endCaretPosition =
 			startCaretPosition + formattedValue.length - previousFormattedValueLength;
 
-		// HACK:
-		// Delay setting the new caret position until the input has been formatted.
-		// If this is ever fixed consider removing `{ delay: DELAY_FOR_FORMATTED_VALUE_IN_MS }` in the tests.
-		setTimeout(() => {
+		let tries = 0;
+    while (previousFormattedValueLength === formattedValue.length && tries < 10) {
+			tries++;
+    }
+
+    if (previousFormattedValueLength !== formattedValue.length) {
+			const endCaretPosition = startCaretPosition + formattedValue.length - previousFormattedValueLength;
 			inputTarget?.setSelectionRange(endCaretPosition, endCaretPosition);
-		}, DELAY_FOR_CARET_UPDATE_IN_MS);
+    }
 
 		// Run callback function when `value` changes
 		onValueChange(value);

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -127,30 +127,23 @@
 		}
 	};
 
+	const handleCaretPosition = () => {
+    // Previous caret position
+    const startCaretPosition = inputTarget?.selectionStart || 0;
+    const previousFormattedValueLength = formattedValue.length;
+
+    // New caret position
+    const endCaretPosition = startCaretPosition + formattedValue.length - previousFormattedValueLength;
+    inputTarget?.setSelectionRange(endCaretPosition, endCaretPosition);
+	}
+
 	const setFormattedValue = () => {
-		// Previous caret position
-		const startCaretPosition = inputTarget?.selectionStart || 0;
-		const previousFormattedValueLength = formattedValue.length;
-
-		// Apply formatting to input
-		formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, 0);
-
-		// Update `value` after formatting
-		setUnformattedValue();
-
-		// New caret position
-		const endCaretPosition =
-			startCaretPosition + formattedValue.length - previousFormattedValueLength;
-
-		// HACK:
-		// Delay setting the new caret position until the input has been formatted.
-		// If this is ever fixed consider removing `{ delay: DELAY_FOR_FORMATTED_VALUE_IN_MS }` in the tests.
-		setTimeout(() => {
-			inputTarget?.setSelectionRange(endCaretPosition, endCaretPosition);
-		}, DELAY_FOR_CARET_UPDATE_IN_MS);
-
-		// Run callback function when `value` changes
-		onValueChange(value);
+    // Apply formatting to input
+    formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, 0);
+    // Update `value` after formatting
+    setUnformattedValue();
+    // Run callback function when `value` changes
+    onValueChange(value);
 	};
 
 	let formattedValue = '';
@@ -190,6 +183,7 @@
 		on:keydown={handleKeyDown}
 		on:keyup={setUnformattedValue}
 		on:blur={setFormattedValue}
+		on:update={handleCaretPosition}
 	/>
 </div>
 

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -12,8 +12,6 @@
 	const DEFAULT_CLASS_FORMATTED_NEGATIVE = 'currencyInput__formatted--negative';
 	const DEFAULT_CLASS_FORMATTED_ZERO = 'currencyInput__formatted--zero';
 
-	const DELAY_FOR_CARET_UPDATE_IN_MS = 0.1;
-
 	interface InputClasses {
 		wrapper?: string;
 		unformatted?: string;

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -12,6 +12,8 @@
 	const DEFAULT_CLASS_FORMATTED_NEGATIVE = 'currencyInput__formatted--negative';
 	const DEFAULT_CLASS_FORMATTED_ZERO = 'currencyInput__formatted--zero';
 
+	const DELAY_FOR_CARET_UPDATE_IN_MS = 0.1;
+
 	interface InputClasses {
 		wrapper?: string;
 		unformatted?: string;
@@ -141,10 +143,11 @@
 			startCaretPosition + formattedValue.length - previousFormattedValueLength;
 
 		// HACK:
-		// Delay setting the new caret position until the input has been formatted
+		// Delay setting the new caret position until the input has been formatted.
+		// If this is ever fixed consider removing `{ delay: DELAY_FOR_DECIMAL_VALUES_IN_MS }` in the tests.
 		setTimeout(() => {
 			inputTarget?.setSelectionRange(endCaretPosition, endCaretPosition);
-		}, 0.1);
+		}, DELAY_FOR_CARET_UPDATE_IN_MS);
 
 		// Run callback function when `value` changes
 		onValueChange(value);

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -127,23 +127,30 @@
 		}
 	};
 
-	const handleCaretPosition = () => {
-    // Previous caret position
-    const startCaretPosition = inputTarget?.selectionStart || 0;
-    const previousFormattedValueLength = formattedValue.length;
-
-    // New caret position
-    const endCaretPosition = startCaretPosition + formattedValue.length - previousFormattedValueLength;
-    inputTarget?.setSelectionRange(endCaretPosition, endCaretPosition);
-	}
-
 	const setFormattedValue = () => {
-    // Apply formatting to input
-    formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, 0);
-    // Update `value` after formatting
-    setUnformattedValue();
-    // Run callback function when `value` changes
-    onValueChange(value);
+		// Previous caret position
+		const startCaretPosition = inputTarget?.selectionStart || 0;
+		const previousFormattedValueLength = formattedValue.length;
+
+		// Apply formatting to input
+		formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, 0);
+
+		// Update `value` after formatting
+		setUnformattedValue();
+
+		// New caret position
+		const endCaretPosition =
+			startCaretPosition + formattedValue.length - previousFormattedValueLength;
+
+		// HACK:
+		// Delay setting the new caret position until the input has been formatted.
+		// If this is ever fixed consider removing `{ delay: DELAY_FOR_FORMATTED_VALUE_IN_MS }` in the tests.
+		setTimeout(() => {
+			inputTarget?.setSelectionRange(endCaretPosition, endCaretPosition);
+		}, DELAY_FOR_CARET_UPDATE_IN_MS);
+
+		// Run callback function when `value` changes
+		onValueChange(value);
 	};
 
 	let formattedValue = '';
@@ -183,7 +190,6 @@
 		on:keydown={handleKeyDown}
 		on:keyup={setUnformattedValue}
 		on:blur={setFormattedValue}
-		on:update={handleCaretPosition}
 	/>
 </div>
 

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -129,12 +129,12 @@ test.describe('CurrencyInput', () => {
 		// Use right arrow keys to position cusror at the end of the input
 		for (let i = 0; i < '₡420,69'.length; i++) await page.keyboard.press('ArrowRight');
 		// Delete the number but keep the currency symbol and sign
-		for (let i = 1; i < '420,69'.length; i++) await page.keyboard.press('Backspace');
+		for (let i = 1; i < '420,69'.length; i++) await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await expect(colonFormattedInput).toHaveValue('-₡');
 		// FIXME: at this point the hidden value should be set to 0 but without formatting `colonFormattedInput`
 		await expect(colonUnformattedInput).toHaveValue('-4');
 
-		await page.keyboard.press('Backspace');
+		await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await expect(colonFormattedInput).toHaveValue('-');
 		// FIXME: at this point the hidden value should be set to 0 but without formatting `colonFormattedInput`
 		await expect(colonUnformattedInput).toHaveValue('-4');
@@ -143,7 +143,7 @@ test.describe('CurrencyInput', () => {
 		await expect(colonFormattedInput).toHaveValue('-₡69,42');
 		await expect(colonUnformattedInput).toHaveValue('-69.42');
 
-		for (let i = 0; i < '-₡69,42'.length; i++) await page.keyboard.press('Backspace');
+		for (let i = 0; i < '-₡69,42'.length; i++) await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await expect(colonUnformattedInput).toHaveValue('0');
 	});
 
@@ -172,7 +172,7 @@ test.describe('CurrencyInput', () => {
 
 		// Check "Backspace" works
 		await selectAll(page);
-		await page.keyboard.press('Backspace');
+		await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await expect(colonUnformattedInput).toHaveValue('0');
 		await expect(colonFormattedInput).toHaveValue('');
 
@@ -216,7 +216,7 @@ test.describe('CurrencyInput', () => {
 
 		await bitcoinFormattedInput.focus();
 		await selectAll(page);
-		await page.keyboard.press('Backspace');
+		await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await expect(bitcoinUnformattedInput).toHaveValue('0');
 		await expect(bitcoinFormattedInput).toHaveValue('');
 
@@ -233,7 +233,7 @@ test.describe('CurrencyInput', () => {
 			await euroFormattedInput.focus();
 
 			await selectAll(page);
-			await page.keyboard.press('Backspace');
+			await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 			await expect(euroUnformattedInput).toHaveValue('0');
 
 			await page.keyboard.type('-111222.33', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
@@ -249,7 +249,7 @@ test.describe('CurrencyInput', () => {
 
 			await bitcoinFormattedInput.focus();
 			await selectAll(page);
-			await page.keyboard.press('Backspace');
+			await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 			await expect(bitcoinUnformattedInput).toHaveValue('0');
 
 			await page.keyboard.type('444555,66', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
@@ -274,7 +274,7 @@ test.describe('CurrencyInput', () => {
 		// The value is reset to 0 because Backspace overrides it
 		await euroFormattedInput.focus();
 		await selectAll(page);
-		await page.keyboard.press('Backspace');
+		await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await page.keyboard.type('-');
 		await colonFormattedInput.focus();
 		await expect(euroFormattedInput).toHaveValue('');
@@ -336,7 +336,7 @@ test.describe('CurrencyInput', () => {
 
 		await expect(pesosFormattedInput).toBeVisible();
 		await pesosFormattedInput.focus();
-		await page.keyboard.press('Backspace');
+		await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 	});
 
 	test.skip('Updating chained inputs have the correct behavior', async () => {

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -1,7 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 
-// `DELAY_FOR_CARET_UPDATE_IN_MS` + 0.01
-const DELAY_FOR_DECIMAL_VALUES_IN_MS = 0.11;
+const DELAY_FOR_FORMATTED_VALUE_IN_MS = 25;
 
 const isMacOs = process.platform === 'darwin';
 const selectAll = async (page: Page) => {
@@ -111,7 +110,7 @@ test.describe('CurrencyInput', () => {
 		await expect(colonFormattedInput).toHaveValue('');
 
 		await colonFormattedInput.focus();
-		await page.keyboard.type('420,69', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
+		await page.keyboard.type('420,69', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await expect(colonFormattedInput).toHaveValue('₡420,69');
 		await expect(colonUnformattedInput).toHaveValue('420.69');
 		await expect(colonFormattedInput).toHaveClass(/currencyInput__formatted--positive/);
@@ -140,7 +139,7 @@ test.describe('CurrencyInput', () => {
 		// FIXME: at this point the hidden value should be set to 0 but without formatting `colonFormattedInput`
 		await expect(colonUnformattedInput).toHaveValue('-4');
 
-		await page.keyboard.type('69,42', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
+		await page.keyboard.type('69,42', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await expect(colonFormattedInput).toHaveValue('-₡69,42');
 		await expect(colonUnformattedInput).toHaveValue('-69.42');
 
@@ -167,7 +166,7 @@ test.describe('CurrencyInput', () => {
 		await expect(colonFormattedInput).toHaveValue('');
 
 		// Check keyboard shortcuts are allowed
-		await page.keyboard.type('420,69', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
+		await page.keyboard.type('420,69', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await expect(colonFormattedInput).toHaveValue('₡420,69');
 		await expect(colonUnformattedInput).toHaveValue('420.69');
 
@@ -178,7 +177,7 @@ test.describe('CurrencyInput', () => {
 		await expect(colonFormattedInput).toHaveValue('');
 
 		// Add data to the field again
-		await page.keyboard.type('-420,69', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
+		await page.keyboard.type('-420,69', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await expect(colonFormattedInput).toHaveValue('-₡420,69');
 		await expect(colonUnformattedInput).toHaveValue('-420.69');
 
@@ -222,7 +221,7 @@ test.describe('CurrencyInput', () => {
 		await expect(bitcoinFormattedInput).toHaveValue('');
 
 		// Decimals beyond the maximum allowed are rounded
-		await page.keyboard.type('-0.987654329', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
+		await page.keyboard.type('-0.987654329', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 		await expect(bitcoinUnformattedInput).toHaveValue('-0.98765433');
 		await expect(bitcoinFormattedInput).toHaveValue('-฿0.98765433');
 	});
@@ -237,7 +236,7 @@ test.describe('CurrencyInput', () => {
 			await page.keyboard.press('Backspace');
 			await expect(euroUnformattedInput).toHaveValue('0');
 
-			await page.keyboard.type('-111222.33', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
+			await page.keyboard.type('-111222.33', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 			await expect(euroFormattedInput).toHaveValue('€ -111.222,33');
 			await expect(euroUnformattedInput).toHaveValue('-111222.33');
 		});
@@ -253,7 +252,7 @@ test.describe('CurrencyInput', () => {
 			await page.keyboard.press('Backspace');
 			await expect(bitcoinUnformattedInput).toHaveValue('0');
 
-			await page.keyboard.type('444555,66', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
+			await page.keyboard.type('444555,66', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
 			await expect(bitcoinFormattedInput).toHaveValue('฿444,555.66');
 			await expect(bitcoinUnformattedInput).toHaveValue('444555.66');
 		});

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -89,7 +89,9 @@ test.describe('CurrencyInput', () => {
 					euro: '-42069.69',
 					'formatted-euro': '€ -42.069,69',
 					won: '0',
-					'formatted-won': ''
+					'formatted-won': '',
+					pesos: '999',
+					'formatted-pesos': '$ 999',
 				},
 				null,
 				2
@@ -281,7 +283,7 @@ test.describe('CurrencyInput', () => {
 		// Tabbing in Webkit is broken: https://github.com/Canutin/svelte-currency-input/issues/40
 		if (testInfo.project.name !== 'webkit') {
 			const formattedInputs = page.locator('.currencyInput__formatted');
-			expect(await formattedInputs.count()).toBe(8);
+			expect(await formattedInputs.count()).toBe(9);
 
 			await formattedInputs.first().focus();
 			await expect(formattedInputs.nth(0)).toBeFocused();
@@ -304,6 +306,9 @@ test.describe('CurrencyInput', () => {
 
 			await page.keyboard.press('Tab');
 			await expect(formattedInputs.nth(7)).toBeFocused();
+
+			await page.keyboard.press('Tab');
+			await expect(formattedInputs.nth(8)).toBeFocused();
 		}
 	});
 

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 
-const DELAY_FOR_FORMATTED_VALUE_IN_MS = 0;
+const DELAY_FOR_FORMATTED_VALUE_IN_MS = 25;
 
 const isMacOs = process.platform === 'darwin';
 const selectAll = async (page: Page) => {

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -1,5 +1,8 @@
 import { expect, test, type Page } from '@playwright/test';
 
+// `DELAY_FOR_CARET_UPDATE_IN_MS` + 0.01
+const DELAY_FOR_DECIMAL_VALUES_IN_MS = 0.11;
+
 const isMacOs = process.platform === 'darwin';
 const selectAll = async (page: Page) => {
 	isMacOs ? await page.keyboard.press('Meta+A') : await page.keyboard.press('Control+A');
@@ -108,7 +111,7 @@ test.describe('CurrencyInput', () => {
 		await expect(colonFormattedInput).toHaveValue('');
 
 		await colonFormattedInput.focus();
-		await page.keyboard.type('420,69');
+		await page.keyboard.type('420,69', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
 		await expect(colonFormattedInput).toHaveValue('₡420,69');
 		await expect(colonUnformattedInput).toHaveValue('420.69');
 		await expect(colonFormattedInput).toHaveClass(/currencyInput__formatted--positive/);
@@ -137,7 +140,7 @@ test.describe('CurrencyInput', () => {
 		// FIXME: at this point the hidden value should be set to 0 but without formatting `colonFormattedInput`
 		await expect(colonUnformattedInput).toHaveValue('-4');
 
-		await page.keyboard.type('69,42');
+		await page.keyboard.type('69,42', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
 		await expect(colonFormattedInput).toHaveValue('-₡69,42');
 		await expect(colonUnformattedInput).toHaveValue('-69.42');
 
@@ -164,7 +167,7 @@ test.describe('CurrencyInput', () => {
 		await expect(colonFormattedInput).toHaveValue('');
 
 		// Check keyboard shortcuts are allowed
-		await page.keyboard.type('420,69');
+		await page.keyboard.type('420,69', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
 		await expect(colonFormattedInput).toHaveValue('₡420,69');
 		await expect(colonUnformattedInput).toHaveValue('420.69');
 
@@ -175,7 +178,7 @@ test.describe('CurrencyInput', () => {
 		await expect(colonFormattedInput).toHaveValue('');
 
 		// Add data to the field again
-		await page.keyboard.type('-420,69');
+		await page.keyboard.type('-420,69', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
 		await expect(colonFormattedInput).toHaveValue('-₡420,69');
 		await expect(colonUnformattedInput).toHaveValue('-420.69');
 
@@ -219,7 +222,7 @@ test.describe('CurrencyInput', () => {
 		await expect(bitcoinFormattedInput).toHaveValue('');
 
 		// Decimals beyond the maximum allowed are rounded
-		await page.keyboard.type('-0.987654329');
+		await page.keyboard.type('-0.987654329', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
 		await expect(bitcoinUnformattedInput).toHaveValue('-0.98765433');
 		await expect(bitcoinFormattedInput).toHaveValue('-฿0.98765433');
 	});
@@ -234,7 +237,7 @@ test.describe('CurrencyInput', () => {
 			await page.keyboard.press('Backspace');
 			await expect(euroUnformattedInput).toHaveValue('0');
 
-			await page.keyboard.type('-111222.33');
+			await page.keyboard.type('-111222.33', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
 			await expect(euroFormattedInput).toHaveValue('€ -111.222,33');
 			await expect(euroUnformattedInput).toHaveValue('-111222.33');
 		});
@@ -250,7 +253,7 @@ test.describe('CurrencyInput', () => {
 			await page.keyboard.press('Backspace');
 			await expect(bitcoinUnformattedInput).toHaveValue('0');
 
-			await page.keyboard.type('444555,66');
+			await page.keyboard.type('444555,66', { delay: DELAY_FOR_DECIMAL_VALUES_IN_MS });
 			await expect(bitcoinFormattedInput).toHaveValue('฿444,555.66');
 			await expect(bitcoinUnformattedInput).toHaveValue('444555.66');
 		});

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 
-const DELAY_FOR_FORMATTED_VALUE_IN_MS = 25;
+const DELAY_FOR_FORMATTED_VALUE_IN_MS = 0;
 
 const isMacOs = process.platform === 'darwin';
 const selectAll = async (page: Page) => {

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -129,12 +129,14 @@ test.describe('CurrencyInput', () => {
 		// Use right arrow keys to position cusror at the end of the input
 		for (let i = 0; i < '₡420,69'.length; i++) await page.keyboard.press('ArrowRight');
 		// Delete the number but keep the currency symbol and sign
-		for (let i = 1; i < '420,69'.length; i++) await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
+		for (let i = 1; i < '420,69'.length; i++) await page.keyboard.press('Backspace');
+		await page.waitForTimeout(DELAY_FOR_FORMATTED_VALUE_IN_MS);
 		await expect(colonFormattedInput).toHaveValue('-₡');
 		// FIXME: at this point the hidden value should be set to 0 but without formatting `colonFormattedInput`
 		await expect(colonUnformattedInput).toHaveValue('-4');
 
-		await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
+		await page.keyboard.press('Backspace');
+		await page.waitForTimeout(DELAY_FOR_FORMATTED_VALUE_IN_MS);
 		await expect(colonFormattedInput).toHaveValue('-');
 		// FIXME: at this point the hidden value should be set to 0 but without formatting `colonFormattedInput`
 		await expect(colonUnformattedInput).toHaveValue('-4');
@@ -143,7 +145,8 @@ test.describe('CurrencyInput', () => {
 		await expect(colonFormattedInput).toHaveValue('-₡69,42');
 		await expect(colonUnformattedInput).toHaveValue('-69.42');
 
-		for (let i = 0; i < '-₡69,42'.length; i++) await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
+		for (let i = 0; i < '-₡69,42'.length; i++) await page.keyboard.press('Backspace');
+		await page.waitForTimeout(DELAY_FOR_FORMATTED_VALUE_IN_MS);
 		await expect(colonUnformattedInput).toHaveValue('0');
 	});
 
@@ -172,7 +175,8 @@ test.describe('CurrencyInput', () => {
 
 		// Check "Backspace" works
 		await selectAll(page);
-		await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
+		await page.keyboard.press('Backspace');
+		await page.waitForTimeout(DELAY_FOR_FORMATTED_VALUE_IN_MS);
 		await expect(colonUnformattedInput).toHaveValue('0');
 		await expect(colonFormattedInput).toHaveValue('');
 
@@ -216,7 +220,8 @@ test.describe('CurrencyInput', () => {
 
 		await bitcoinFormattedInput.focus();
 		await selectAll(page);
-		await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
+		await page.keyboard.press('Backspace');
+		await page.waitForTimeout(DELAY_FOR_FORMATTED_VALUE_IN_MS);
 		await expect(bitcoinUnformattedInput).toHaveValue('0');
 		await expect(bitcoinFormattedInput).toHaveValue('');
 
@@ -233,7 +238,8 @@ test.describe('CurrencyInput', () => {
 			await euroFormattedInput.focus();
 
 			await selectAll(page);
-			await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
+			await page.keyboard.press('Backspace');
+			await page.waitForTimeout(DELAY_FOR_FORMATTED_VALUE_IN_MS);
 			await expect(euroUnformattedInput).toHaveValue('0');
 
 			await page.keyboard.type('-111222.33', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
@@ -249,7 +255,8 @@ test.describe('CurrencyInput', () => {
 
 			await bitcoinFormattedInput.focus();
 			await selectAll(page);
-			await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
+			await page.keyboard.press('Backspace');
+			await page.waitForTimeout(DELAY_FOR_FORMATTED_VALUE_IN_MS);
 			await expect(bitcoinUnformattedInput).toHaveValue('0');
 
 			await page.keyboard.type('444555,66', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
@@ -274,7 +281,8 @@ test.describe('CurrencyInput', () => {
 		// The value is reset to 0 because Backspace overrides it
 		await euroFormattedInput.focus();
 		await selectAll(page);
-		await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
+		await page.keyboard.press('Backspace');
+		await page.waitForTimeout(DELAY_FOR_FORMATTED_VALUE_IN_MS);
 		await page.keyboard.type('-');
 		await colonFormattedInput.focus();
 		await expect(euroFormattedInput).toHaveValue('');
@@ -336,7 +344,7 @@ test.describe('CurrencyInput', () => {
 
 		await expect(pesosFormattedInput).toBeVisible();
 		await pesosFormattedInput.focus();
-		await page.keyboard.press('Backspace', { delay: DELAY_FOR_FORMATTED_VALUE_IN_MS });
+		await page.keyboard.press('Backspace');
 	});
 
 	test.skip('Updating chained inputs have the correct behavior', async () => {


### PR DESCRIPTION
- Replace the `setTimeout` hack for a loop that waits that the length of the `formattedValue` has changed.
- A new field was introduced in the [last PR](https://github.com/fmaclen/svelte-currency-input/pull/48) and forgot to properly update the tests.