### PR TITLE
fix: apply fraction digits formatting when the value doesn't have cents

### DIFF
--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -135,13 +135,13 @@
 		}
 	};
 
-	const setFormattedValue = (shouldFormatFractionDigits?: boolean) => {
+	const setFormattedValue = (hasMinFractionDigits?: boolean) => {
 		// Previous caret position
 		const startCaretPosition = inputTarget?.selectionStart || 0;
 		const previousFormattedValueLength = formattedValue.length;
 
 		// Apply formatting to input
-		formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, shouldFormatFractionDigits ? fractionDigits : 0);
+		formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, hasMinFractionDigits ? fractionDigits : 0);
 
 		// Update `value` after formatting
 		setUnformattedValue();

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -66,10 +66,10 @@
 
 	// Formats the value when the input loses focus and sets the correct number of
 	// fraction digits when the value is zero
-	const handleOnBlur = () => setFormattedValue(fractionDigits);
+	const handleOnBlur = () => setFormattedValue(true);
 
 	// Also set the correct fraction digits when the value is zero on initial load
-	onMount(() => setFormattedValue(fractionDigits));
+	onMount(() => setFormattedValue(true));
 
 	let inputTarget: HTMLInputElement;
 	const currencyDecimal = new Intl.NumberFormat(locale).format(1.1).charAt(1); // '.' or ','
@@ -135,13 +135,13 @@
 		}
 	};
 
-	const setFormattedValue = (fractionDigitsOnZero?: number) => {
+	const setFormattedValue = (shouldFormatFractionDigits?: boolean) => {
 		// Previous caret position
 		const startCaretPosition = inputTarget?.selectionStart || 0;
 		const previousFormattedValueLength = formattedValue.length;
 
 		// Apply formatting to input
-		formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, fractionDigitsOnZero || 0);
+		formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, shouldFormatFractionDigits ? fractionDigits : 0);
 
 		// Update `value` after formatting
 		setUnformattedValue();

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { onMount } from "svelte";
+
 	const DEFAULT_LOCALE = 'en-US';
 	const DEFAULT_CURRENCY = 'USD';
 	const DEFAULT_NAME = 'total';
@@ -61,6 +63,13 @@
 		if (!isDeletion && !isModifier && !isArrowKey && isInvalidCharacter && !isTab)
 			event.preventDefault();
 	};
+
+	// Formats the value when the input loses focus and sets the correct number of
+	// fraction digits when the value is zero
+	const handleOnBlur = () => setFormattedValue(fractionDigits);
+
+	// Also set the correct fraction digits when the value is zero on initial load
+	onMount(() => setFormattedValue(fractionDigits));
 
 	let inputTarget: HTMLInputElement;
 	const currencyDecimal = new Intl.NumberFormat(locale).format(1.1).charAt(1); // '.' or ','
@@ -126,13 +135,13 @@
 		}
 	};
 
-	const setFormattedValue = () => {
+	const setFormattedValue = (fractionDigitsOnZero?: number) => {
 		// Previous caret position
 		const startCaretPosition = inputTarget?.selectionStart || 0;
 		const previousFormattedValueLength = formattedValue.length;
 
 		// Apply formatting to input
-		formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, 0);
+		formattedValue = isZero ? '' : formatCurrency(value, fractionDigits, fractionDigitsOnZero || 0);
 
 		// Update `value` after formatting
 		setUnformattedValue();
@@ -187,7 +196,7 @@
 		bind:value={formattedValue}
 		on:keydown={handleKeyDown}
 		on:keyup={setUnformattedValue}
-		on:blur={setFormattedValue}
+		on:blur={handleOnBlur}
 	/>
 </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -64,6 +64,7 @@
 				}
 			}}
 		/>
+		<CurrencyInput name="rupees" value={678} locale="hi-IN" currency="INR" fractionDigits={3} />
 	</div>
 
 	<nav class="demoForm__output">

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -365,6 +365,7 @@ test.describe('CurrencyInput', () => {
 		await page.keyboard.press('Backspace');
 		await page.keyboard.type('123');
 		await expect(rupeesFormattedInput).toHaveValue('₹123');
+		await expect(rupeesFormattedInput).not.toHaveValue('₹123.000');
 
 		await page.locator('body').click(); // Click outside the input to trigger formatting
 		await expect(rupeesFormattedInput).toHaveValue('₹123.000');


### PR DESCRIPTION
Fixes #52