### PR TITLE
fix: update package.json to support Svelte legacy tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,11 +26,13 @@
 				"publint": "^0.2.5",
 				"sass": "^1.69.0",
 				"semantic-release": "^19.0.5",
-				"svelte": "^4.0.5",
 				"svelte-check": "^3.4.3",
 				"tslib": "^2.4.1",
 				"typescript": "^5.0.0",
 				"vite": "^4.4.2"
+			},
+			"peerDependencies": {
+				"svelte": "^3.59.2"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -39,18 +41,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.2.1",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -344,29 +334,8 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -844,11 +813,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/estree": {
-			"version": "1.0.3",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.14",
 			"dev": true,
@@ -1205,14 +1169,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/aria-query": {
-			"version": "5.3.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
 		"node_modules/array-ify": {
 			"version": "1.0.0",
 			"dev": true,
@@ -1232,14 +1188,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/axobject-query": {
-			"version": "3.2.1",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -1421,18 +1369,6 @@
 				"wrap-ansi": "^7.0.0"
 			}
 		},
-		"node_modules/code-red": {
-			"version": "1.0.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@types/estree": "^1.0.1",
-				"acorn": "^8.10.0",
-				"estree-walker": "^3.0.3",
-				"periscopic": "^3.1.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"dev": true,
@@ -1594,18 +1530,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/css-tree": {
-			"version": "2.3.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mdn-data": "2.0.30",
-				"source-map-js": "^1.0.1"
-			},
-			"engines": {
-				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-			}
-		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
 			"dev": true,
@@ -1754,14 +1678,6 @@
 			"version": "2.3.1",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/dequal": {
-			"version": "2.0.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/detect-indent": {
 			"version": "6.1.0",
@@ -2424,14 +2340,6 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"node_modules/estree-walker": {
-			"version": "3.0.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0"
 			}
 		},
 		"node_modules/esutils": {
@@ -3133,14 +3041,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-reference": {
-			"version": "3.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "*"
-			}
-		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
 			"dev": true,
@@ -3356,11 +3256,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/locate-character": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"dev": true,
@@ -3497,11 +3392,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
-		},
-		"node_modules/mdn-data": {
-			"version": "2.0.30",
-			"dev": true,
-			"license": "CC0-1.0"
 		},
 		"node_modules/meow": {
 			"version": "8.1.2",
@@ -6619,16 +6509,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/periscopic": {
-			"version": "3.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0",
-				"estree-walker": "^3.0.0",
-				"is-reference": "^3.0.0"
-			}
-		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"dev": true,
@@ -7761,26 +7641,12 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "4.2.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@ampproject/remapping": "^2.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"acorn": "^8.9.0",
-				"aria-query": "^5.3.0",
-				"axobject-query": "^3.2.1",
-				"code-red": "^1.0.3",
-				"css-tree": "^2.3.1",
-				"estree-walker": "^3.0.3",
-				"is-reference": "^3.0.1",
-				"locate-character": "^3.0.0",
-				"magic-string": "^0.30.4",
-				"periscopic": "^3.1.0"
-			},
+			"version": "3.59.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
+			"integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+			"peer": true,
 			"engines": {
-				"node": ">=16"
+				"node": ">= 8"
 			}
 		},
 		"node_modules/svelte-check": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"!dist/**/*.spec.*"
 	],
 	"peerDependencies": {
-		"svelte": "^4.0.0"
+		"svelte": "^3.59.2"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.39.0",
@@ -49,6 +49,8 @@
 		"typescript": "^5.0.0",
 		"vite": "^4.4.2"
 	},
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"type": "module",
 	"description": "A form input that converts numbers to currencies as you type in localized formats",
 	"keywords": [


### PR DESCRIPTION
- REF https://kit.svelte.dev/docs/packaging#anatomy-of-a-package-json-svelte
- Downgrade to Svelte 3.59.2 because 4.0.0 exports the package using a type `SvelteComponent` which causes the types to break when used in Svelte 3.x — REF https://github.com/sveltejs/svelte/pull/8512

Fixes #68