### PR TITLE
fix: set `inputmode` dynamically based on fractionDigits

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
 		"!dist/**/*.test.*",
 		"!dist/**/*.spec.*"
 	],
-	"peerDependencies": {
-		"svelte": "^3.59.2"
-	},
 	"devDependencies": {
 		"@playwright/test": "^1.39.0",
 		"@sveltejs/adapter-auto": "^2.0.0",

--- a/src/app.html
+++ b/src/app.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+		<title>svelte-currency-input | Demo</title>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -204,7 +204,7 @@
 			: ''}
 		"
 		type="text"
-		inputmode="numeric"
+		inputmode={fractionDigits > 0 ? "decimal" : "numeric"}
 		name={`formatted-${name}`}
 		required={required && !isZero}
 		placeholder={handlePlaceholder(placeholder)}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,28 @@
 </script>
 
 <form class="demoForm" on:submit={handleSubmit}>
+	<nav class="demoForm__nav">
+		<h1 class="demoForm__h1">svelte-currency-input</h1>
+		<a class="demoForm__a" href="https://github.com/canutin/svelte-currency-input" target="_blank"
+			>GitHub repository</a
+		>
+		<a
+			class="demoForm__a"
+			href="https://github.com/canutin/svelte-currency-input/issues"
+			target="_blank">Known issues</a
+		>
+		<a
+			class="demoForm__a"
+			href="https://github.com/canutin/svelte-currency-input#contributing"
+			target="_blank">Contribute</a
+		>
+		<a
+			class="demoForm__a"
+			href="https://www.npmjs.com/package/@canutin/svelte-currency-input"
+			target="_blank">NPM</a
+		>
+	</nav>
+
 	<div class="demoForm__container">
 		<CurrencyInput name="default" value={-42069.69} />
 		<CurrencyInput name="colon" locale="es-CR" currency="CRC" />
@@ -66,7 +88,7 @@
 		/>
 		<CurrencyInput name="rupees" value={678} locale="hi-IN" currency="INR" fractionDigits={3} />
 		<CurrencyInput name="soles" value={0} isZeroNullish={true} placeholder={null} locale="es-PE" currency="PEN" />
-		<CurrencyInput name="dinars" value={0} placeholder={"How many Dinars?"} locale="en-US" currency="RSD" />
+		<CurrencyInput name="dinars" value={0} placeholder={"How many Dinars?"} locale="en-US" currency="RSD" fractionDigits={0} />
 	</div>
 
 	<nav class="demoForm__output">
@@ -75,27 +97,6 @@
 		<pre class="demoForm__pre {!output && 'demoForm__pre--placeholder'}">{output
 				? output
 				: 'Submit form to see a JSON output of the values'}</pre>
-	</nav>
-
-	<nav class="demoForm__nav">
-		<a class="demoForm__a" href="https://github.com/canutin/svelte-currency-input" target="_blank"
-			>GitHub repository</a
-		>
-		<a
-			class="demoForm__a"
-			href="https://github.com/canutin/svelte-currency-input/issues"
-			target="_blank">Known issues</a
-		>
-		<a
-			class="demoForm__a"
-			href="https://github.com/canutin/svelte-currency-input#contributing"
-			target="_blank">Contribute</a
-		>
-		<a
-			class="demoForm__a"
-			href="https://www.npmjs.com/package/@canutin/svelte-currency-input"
-			target="_blank">NPM</a
-		>
 	</nav>
 </form>
 
@@ -113,7 +114,7 @@
 
 		font-family: sans-serif;
 		box-sizing: border-box;
-		height: 100vh;
+		min-height: 100vh;
 		margin: 0;
 		background-color: #eaeaea;
 		display: flex;
@@ -121,6 +122,14 @@
 		justify-content: center;
 		place-items: center;
 		padding: var(--gap);
+
+		@media (max-width: 768px) {
+			--gap: 48px;
+		}
+
+		@media (max-width: 512px) {
+			--gap: 32px;
+		}
 	}
 
 	form.demoForm {
@@ -136,13 +145,36 @@
 		justify-content: center;
 		gap: calc(var(--gap) / 2);
 		height: max-content;
+
+		@media (max-width: 768px) {
+			grid-template-columns: repeat(2, 1fr);
+		}
+		
+		@media (max-width: 512px) {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	h1.demoForm__h1 {
+		color: #333;
+		font-size: 20px;
+		letter-spacing: -0.025em;
+		line-height: 1em;
+		margin: unset;
+		margin-right: auto;
+		text-align: center;
 	}
 
 	nav.demoForm__nav {
 		font-size: 13px;
 		display: flex;
-		column-gap: 16px;
+		gap: 16px;
 		justify-content: center;
+
+		@media (max-width: 512px) {
+			flex-direction: column;
+			gap: 24px;
+		}
 	}
 
 	a.demoForm__a {
@@ -165,7 +197,11 @@
 	nav.demoForm__output {
 		display: grid;
 		grid-template-columns: max-content auto;
-		column-gap: calc(var(--gap) / 2);
+		gap: calc(var(--gap) / 2);
+
+		@media (max-width: 512px) {
+			grid-template-columns: unset;
+		}
 	}
 
 	pre.demoForm__pre {
@@ -174,6 +210,8 @@
 		margin: 0;
 		color: #666;
 		box-sizing: border-box;
+		max-width: 100%;
+		overflow-y: auto;
 	}
 
 	pre.demoForm__pre--placeholder {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -160,9 +160,9 @@
 		font-size: 20px;
 		letter-spacing: -0.025em;
 		line-height: 1em;
-		margin: unset;
+		margin-block: unset;
 		margin-right: auto;
-		text-align: center;
+		padding-right: 16px;
 	}
 
 	nav.demoForm__nav {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,6 +35,11 @@
 			href="https://www.npmjs.com/package/@canutin/svelte-currency-input"
 			target="_blank">NPM</a
 		>
+		<a
+			class="demoForm__a"
+			href="https://svelte.dev/repl/d8f7d22e5b384555b430f62b157ac503?version=3.59.2"
+			target="_blank">REPL</a
+		>
 	</nav>
 
 	<div class="demoForm__container">

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -454,6 +454,20 @@ test.describe('CurrencyInput', () => {
 		await expect(dinarsFormattedInput).toHaveValue('RSD 123.');
 	});
 
+	test("inputmode is set correctly based on fractionDigits", async ({ page }) => {
+		// fractionDigits == undefined (defaults to 2)
+		const solesFormattedInput = page.locator('.currencyInput__formatted[name="formatted-soles"]');
+		await expect(solesFormattedInput).toHaveAttribute('inputmode', 'decimal');
+
+		// fractionDigits == 3
+		const rupeesFormattedInput = page.locator('.currencyInput__formatted[name="formatted-rupees"]');
+		await expect(rupeesFormattedInput).toHaveAttribute('inputmode', 'decimal');
+
+		// fractionDigits == 0
+		const dinarsFormattedInput = page.locator('.currencyInput__formatted[name="formatted-dinars"]');
+		await expect(dinarsFormattedInput).toHaveAttribute('inputmode', 'numeric');
+	});
+
 	test.skip('Updating chained inputs have the correct behavior', async () => {
 		// TODO
 	});


### PR DESCRIPTION
- Sets `inputmode` to `decimal` or `numeric` based on the value of `fractionDigits`.
- Updates the demo page with a responsive layout for mobile devices.

Fixes #69 

<img src="https://github.com/fmaclen/svelte-currency-input/assets/1434675/7ae04eba-fb51-4dbe-9563-218d6c3676f7" width="40%">
<img src="https://github.com/fmaclen/svelte-currency-input/assets/1434675/ca7d4f10-17bd-425a-878c-c9068f852ffb" width="40%">