### PR TITLE
feat: allow form submission when pressing `Enter`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1042,9 +1042,9 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-auto": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.2.5.tgz",
-			"integrity": "sha512-27LR+uKccZ62lgq4N/hvyU2G+hTP9fxWEAfnZcl70HnyfAjMSsGk1z/SjAPXNCD1mVJIE7IFu3TQ8cQ/UH3c0A==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.3.1.tgz",
+			"integrity": "sha512-5Sc7WAxYdL6q9j/+D0jJKjGREGlfIevDyHSQ2eNETHcB1TKlQWHcAo8AS8H1QdjNvSXpvOwNjykDUHPEAyGgdQ==",
 			"dev": true,
 			"dependencies": {
 				"import-meta-resolve": "^4.1.0"
@@ -1054,9 +1054,9 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-cloudflare": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-cloudflare/-/adapter-cloudflare-4.7.3.tgz",
-			"integrity": "sha512-mHw0Jvd+74jj8fkduA8jrVXgsCY3+NwDc7FrDUiwU1Qe5QEuqPUab8Lv+np+4afEuMtFNytxUJsiiWlNN2w10w==",
+			"version": "4.7.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-cloudflare/-/adapter-cloudflare-4.7.4.tgz",
+			"integrity": "sha512-hKvWAfCQLzyNBunXEm5T+yyVfbQ+QNqnyqI0+lDoVYNQ58Yg/EPLEQIBS5aNpZgaEuBtY2tnegLsoPS8ZRcaIg==",
 			"dev": true,
 			"dependencies": {
 				"@cloudflare/workers-types": "^4.20231121.0",
@@ -1069,9 +1069,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.7.1.tgz",
-			"integrity": "sha512-TBVnkwgYQT3EafGQK6Eyh5FlLEBlRhCmqPTwcdOs+QdnyUc3eCAxRWtXlFxIWtmk6pqv11zdng8qTpThdTogew==",
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.7.4.tgz",
+			"integrity": "sha512-3DOPQYck3CpAmPgGq/HuhJMCCz8GF0ukbompPJQ2zShoSzrEKW9iG/l0nZmaxMvuOO3NNLmZj8F3W9uzqmkNdw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {

--- a/src/lib/CurrencyInput.svelte
+++ b/src/lib/CurrencyInput.svelte
@@ -75,6 +75,7 @@
 		const isModifier = event.metaKey || event.altKey || event.ctrlKey;
 		const isArrowKey = event.key === 'ArrowLeft' || event.key === 'ArrowRight';
 		const isTab = event.key === 'Tab';
+		const isEnter = event.key === 'Enter';
 		// Keys that are not a digit, comma, period or minus sign
 		const isInvalidCharacter = !/^\d|,|\.|-$/g.test(event.key);
 
@@ -88,7 +89,7 @@
 
 		if (
 			isPunctuationDuplicated() ||
-			(!isDeletion && !isModifier && !isArrowKey && isInvalidCharacter && !isTab)
+			(!isDeletion && !isModifier && !isArrowKey && isInvalidCharacter && !isTab && !isEnter)
 		)
 			event.preventDefault();
 	}

--- a/tests/svelte-currency-input.test.ts
+++ b/tests/svelte-currency-input.test.ts
@@ -534,4 +534,18 @@ test.describe('CurrencyInput', () => {
 		await expect(fourTwentySixNineInput).toBeVisible();
 		await expect(fourTwentySixNineInput).toHaveValue('-$42,069.69');
 	});
+
+	test('pressing enter submits the form', async ({ page }) => {
+		const preTag = page.locator('.demoForm__pre');
+		await expect(preTag).toContainText('Submit form to see a JSON output of the values');
+		await expect(preTag).not.toContainText('bitcoin');
+
+		const allInputs = page.locator('.currencyInput__formatted');
+		await allInputs.first().focus();
+		await expect(allInputs.first()).toHaveValue('-$42,069.69');
+
+		await page.keyboard.press('Enter');
+		await expect(preTag).not.toContainText('Submit form to see a JSON output of the values');
+		await expect(preTag).toContainText('bitcoin');
+	});
 });


### PR DESCRIPTION
The default behavior of `input` tags is to submit the parent `form` when pressing `Enter`.
This PR allows the `Enter` keypress event to behave the way it normally does.