### PR TITLE
feat: enable npm publishing with provenance

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,7 +13,6 @@
 		[
 			"@semantic-release/npm",
 			{
-				"npmPublish": false,
 				"provenance": true
 			}
 		],


### PR DESCRIPTION
## Summary

Enables automated npm publishing for the `next` branch with provenance attestation.

## What happens after merge

1. Semantic release will analyze commits and bump version to `1.0.0-next.6`
2. Package will be published to npm with the `next` dist-tag
3. Users can install with: `npm install @canutin/svelte-currency-input@next`
4. Package will have a verified provenance badge on npm