### PR TITLE
fix: round abbreviation values to avoid floating-point precision errors

### DIFF
--- a/src/lib/utils/parseAbbrValue.ts
+++ b/src/lib/utils/parseAbbrValue.ts
@@ -25,8 +25,18 @@ export const parseAbbrValue = (value: string, decimalSeparator = '.'): number | 
 	if (match) {
 		const [, digits, , abbr] = match;
 		const multiplier = abbrMap[abbr.toLowerCase()];
+		const result = Number(digits.replace(decimalSeparator, '.')) * multiplier;
 
-		return Number(digits.replace(decimalSeparator, '.')) * multiplier;
+		// Round based on input precision to avoid floating-point errors
+		// e.g. 4.1 * 1000000 = 4099999.9999999995 should become 4100000
+		// but 1.12345678 * 1000 = 1123.45678 should preserve all decimals
+		const decimalPart = digits.split(decimalSeparator)[1] || '';
+		const inputDecimals = decimalPart.length;
+		const multiplierZeros = Math.log10(multiplier);
+		const resultDecimals = Math.max(0, inputDecimals - multiplierZeros);
+		const precision = Math.pow(10, resultDecimals);
+
+		return Math.round(result * precision) / precision;
 	}
 
 	return undefined;

--- a/tests/e2e/abbreviations.test.ts
+++ b/tests/e2e/abbreviations.test.ts
@@ -14,8 +14,8 @@ test('expands k to thousands', async ({ page }) => {
 test('expands m to millions', async ({ page }) => {
 	const input = page.getByLabel('expands m to millions');
 	await expect(input).toHaveValue('');
-	await input.fill('2.5m');
-	await expect(input).toHaveValue('$2,500,000');
+	await input.fill('4.1m');
+	await expect(input).toHaveValue('$4,100,000');
 });
 
 test('expands b to billions', async ({ page }) => {

--- a/tests/unit/parseAbbrValue.spec.ts
+++ b/tests/unit/parseAbbrValue.spec.ts
@@ -78,4 +78,9 @@ describe('parseAbbrValue', () => {
 		expect(parseAbbrValue('1,2k', ',')).toBe(1200);
 		expect(parseAbbrValue('2,3m', ',')).toBe(2300000);
 	});
+
+	it('should handle high precision decimals (e.g. Bitcoin with 8 decimal places)', () => {
+		expect(parseAbbrValue('1.12345678k')).toBe(1123.45678);
+		expect(parseAbbrValue('0.00000001k')).toBe(0.00001);
+	});
 });


### PR DESCRIPTION
## Summary

- Fixes issue where typing `4.1m` would display `$NaN.1` due to JavaScript floating-point precision errors (`4.1 * 1000000 = 4099999.9999999995`)
- Rounds based on input precision to eliminate floating-point errors while preserving intentional high-precision decimals (e.g. Bitcoin with 8 decimal places)

Closes #94